### PR TITLE
seperate vars by space and not comma

### DIFF
--- a/Ansible/Command/AbstractAnsibleCommand.php
+++ b/Ansible/Command/AbstractAnsibleCommand.php
@@ -150,7 +150,7 @@ abstract class AbstractAnsibleCommand
      * @param string $glue
      * @return string
      */
-    protected function checkParam($param, $glue = ',')
+    protected function checkParam($param, $glue = ' ')
     {
         if (is_array($param)) {
             $param = implode($glue, $param);

--- a/Ansible/Command/AnsiblePlaybook.php
+++ b/Ansible/Command/AnsiblePlaybook.php
@@ -144,7 +144,7 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
      */
     public function extraVars($extraVars = '')
     {
-        $extraVars = $this->checkParam($extraVars, ',');
+        $extraVars = $this->checkParam($extraVars, ' ');
         $this->addOption('--extra-vars', $extraVars);
 
         return $this;


### PR DESCRIPTION
Variables passed via command line have to be separated by space and not comma.
See: https://docs.ansible.com/ansible/playbooks_variables.html#passing-variables-on-the-command-line