### PR TITLE
don't allow to fail on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
-    - php: 7.0
   include:
     - php: 5.4
     - php: 5.5


### PR DESCRIPTION
PHP 7 already is in RC state. Thus, allowing to fail on it seems to be wrong to me (tests currently pass).