### PR TITLE
Allow project to work with v3.0 of `symfony-process`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "symfony/process": "~2.6"
+    "symfony/process": "~2.6|~3.0"
   },
   "require-dev": {
     "phpunit\/phpunit": "~4.0",


### PR DESCRIPTION
Looking to embed this into a Laravel project which requires v3.0.2 of `symfony-process` - current composer restraints means it won't install!