### PR TITLE
tweak Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 env:
   global:
@@ -22,10 +22,11 @@ matrix:
     - php: 5.6
       env: PROCESS_VERSION="2.7.x"
     - php: 5.6
-      env: PROCESS_VERSION="2.8.x@dev"
+      env: PROCESS_VERSION="2.8.x"
     - php: 7.0
     - php: hhvm
 
 before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$PROCESS_VERSION" != "" ]; then composer require symfony/process:${PROCESS_VERSION} --dev --no-update; fi
   - if [ "$deps" = "" ]; then composer install; fi


### PR DESCRIPTION
* only cache downloaded package archives (but not Packagist's metadata)
* prefer stable `symfony/process` versions
* disable Xdebug to speed up builds