### PR TITLE
Fixes command checking

### DIFF
--- a/Ansible/Ansible.php
+++ b/Ansible/Ansible.php
@@ -127,7 +127,7 @@ final class Ansible
     {
         // normally ansible is in /usr/local/bin/*
         if ('' === $command) {
-            if (true === shell_exec('which ' . $default)) {
+            if (shell_exec('which ' . $default)) {
                 $command = $default;
             } else { // not testable without ansible installation
                 throw new CommandException('No ' . $default . ' executable present in PATH!');


### PR DESCRIPTION
Shell_exec returns the output from the executed command or NULL if an error occurred or the command produces no output.
