### PR TITLE
The ansible parameters generation seems to be buggy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 vendor
 tmp
 
-#files
-composer.lock
 
 # Unit Test files
 .phpunit.result.cache

--- a/Asm/Ansible/Ansible.php
+++ b/Asm/Ansible/Ansible.php
@@ -18,6 +18,9 @@ use Asm\Ansible\Exception\CommandException;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Process\ProcessBuilderInterface;
 use Asm\Ansible\Utils\Env;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 /**
  * Ansible command factory
@@ -25,10 +28,14 @@ use Asm\Ansible\Utils\Env;
  * @package Asm\Ansible
  * @author Marc Aschmann <maschmann@gmail.com>
  */
-final class Ansible
+final class Ansible implements LoggerAwareInterface
 {
-
     const DEFAULT_TIMEOUT = 300;
+
+    /**
+     * Adds a local $logger instance and the setter.
+     */
+    use LoggerAwareTrait;
 
     /**
      * @var string
@@ -55,16 +62,14 @@ final class Ansible
      * @param string $playbookCommand path to playbook executable, default ansible-playbook
      * @param string $galaxyCommand path to galaxy executable, default ansible-galaxy
      */
-    public function __construct(
-        string $ansibleBaseDir,
-        string $playbookCommand = '',
-        string $galaxyCommand = ''
-    ) {
+    public function __construct(string $ansibleBaseDir, string $playbookCommand = '', string $galaxyCommand = '')
+    {
         $this->ansibleBaseDir = $this->checkDir($ansibleBaseDir);
         $this->playbookCommand = $this->checkCommand($playbookCommand, 'ansible-playbook');
         $this->galaxyCommand = $this->checkCommand($galaxyCommand, 'ansible-galaxy');
 
         $this->timeout = Ansible::DEFAULT_TIMEOUT;
+        $this->logger= new NullLogger();
     }
 
     /**
@@ -75,7 +80,8 @@ final class Ansible
     public function playbook(): AnsiblePlaybookInterface
     {
         return new AnsiblePlaybook(
-            $this->createProcess($this->playbookCommand)
+            $this->createProcess($this->playbookCommand),
+            $this->logger
         );
     }
 
@@ -87,7 +93,8 @@ final class Ansible
     public function galaxy(): AnsibleGalaxyInterface
     {
         return new AnsibleGalaxy(
-            $this->createProcess($this->galaxyCommand)
+            $this->createProcess($this->galaxyCommand),
+            $this->logger
         );
     }
 

--- a/Asm/Ansible/Ansible.php
+++ b/Asm/Ansible/Ansible.php
@@ -181,8 +181,8 @@ final class Ansible implements LoggerAwareInterface
         if (!Env::isWindows())
             return is_executable($command);
 
-        foreach (['exe', 'com','bat','cmd','ps1'] as $ext){
-            if (strtolower(substr($command, -3,3))=== $ext)
+        foreach (['exe', 'com', 'bat', 'cmd', 'ps1'] as $ext) {
+            if (strtolower(substr($command, -3, 3)) === $ext)
                 return true;
         }
 

--- a/Asm/Ansible/Command/AbstractAnsibleCommand.php
+++ b/Asm/Ansible/Command/AbstractAnsibleCommand.php
@@ -34,7 +34,7 @@ abstract class AbstractAnsibleCommand
     protected $processBuilder;
 
     /**
-     * @var array
+     * @var Option[]
      */
     private $options;
 
@@ -90,7 +90,7 @@ abstract class AbstractAnsibleCommand
      */
     protected function addOption(string $name, string $value): void
     {
-        $this->options[$name] = $value;
+        $this->options[] = new Option($name, $value);
     }
 
     /**
@@ -112,8 +112,8 @@ abstract class AbstractAnsibleCommand
     {
         $options = [];
 
-        foreach ($this->options as $name => $value) {
-            $options[] = $name . '=' . $value;
+        foreach ($this->options as $option) {
+            $options[] = $option->toString();
         }
 
         return $options;

--- a/Asm/Ansible/Command/AbstractAnsibleCommand.php
+++ b/Asm/Ansible/Command/AbstractAnsibleCommand.php
@@ -14,6 +14,7 @@ use Asm\Ansible\Process\ProcessBuilderInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Process\Process;
 
 /**
  * Class AbstractAnsibleCommand
@@ -183,7 +184,7 @@ abstract class AbstractAnsibleCommand
             ->getProcess();
 
         // Logging the command
-        $this->logger->debug('Executing: ' . $process->getCommandLine());
+        $this->logger->debug('Executing: ' . $this->getProcessCommandline($process));
 
         // exit code
         $result = $process->run($callback);
@@ -198,5 +199,25 @@ abstract class AbstractAnsibleCommand
         }
 
         return $result;
+    }
+
+    /**
+     * Builds the complete commandline inclusive of the environment variables.
+     * @param Process $process The process instance.
+     * @return string
+     */
+    protected function getProcessCommandline(Process $process): string
+    {
+        $commandline = $process->getCommandLine();
+        if (count($process->getEnv()) === 0)
+            return $commandline;
+
+        // Here: we also need to dump the environment variables
+        $vars = [];
+        foreach ($process->getEnv() as $var => $value) {
+            $vars[] = sprintf('%s=\'%s\'', $var, $value);
+        }
+
+        return sprintf('%s %s', implode(' ', $vars), $commandline);
     }
 }

--- a/Asm/Ansible/Command/AbstractAnsibleCommand.php
+++ b/Asm/Ansible/Command/AbstractAnsibleCommand.php
@@ -11,6 +11,9 @@
 namespace Asm\Ansible\Command;
 
 use Asm\Ansible\Process\ProcessBuilderInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Class AbstractAnsibleCommand
@@ -20,6 +23,10 @@ use Asm\Ansible\Process\ProcessBuilderInterface;
  */
 abstract class AbstractAnsibleCommand
 {
+    /**
+     * Adds a local $logger instance and the setter.
+     */
+    use LoggerAwareTrait;
     /**
      * @var ProcessBuilderInterface
      */
@@ -42,13 +49,15 @@ abstract class AbstractAnsibleCommand
 
     /**
      * @param ProcessBuilderInterface $processBuilder
+     * @param LoggerInterface|null         $logger
      */
-    public function __construct(ProcessBuilderInterface $processBuilder)
+    public function __construct(ProcessBuilderInterface $processBuilder, LoggerInterface $logger = null)
     {
         $this->processBuilder = $processBuilder;
         $this->options = [];
         $this->parameters = [];
         $this->baseOptions = [];
+        $this->setLogger($logger ?? new NullLogger());
     }
 
     /**
@@ -172,6 +181,9 @@ abstract class AbstractAnsibleCommand
                 $this->prepareArguments()
             )
             ->getProcess();
+
+        // Logging the command
+        $this->logger->debug('Executing: ' . $process->getCommandLine());
 
         // exit code
         $result = $process->run($callback);

--- a/Asm/Ansible/Command/AnsibleCommandInterface.php
+++ b/Asm/Ansible/Command/AnsibleCommandInterface.php
@@ -10,13 +10,15 @@
 
 namespace Asm\Ansible\Command;
 
+use Psr\Log\LoggerAwareInterface;
+
 /**
  * Interface AnsibleCommandInterface
  *
  * @package Asm\Ansible\Command
  * @author Marc Aschmann <maschmann@gmail.com>
  */
-interface AnsibleCommandInterface
+interface AnsibleCommandInterface extends LoggerAwareInterface
 {
     /**
      * Executes a command process.

--- a/Asm/Ansible/Command/AnsibleGalaxy.php
+++ b/Asm/Ansible/Command/AnsibleGalaxy.php
@@ -18,7 +18,6 @@ namespace Asm\Ansible\Command;
  */
 final class AnsibleGalaxy extends AbstractAnsibleCommand implements AnsibleGalaxyInterface
 {
-
     /**
      * Executes a command process.
      * Returns either exitcode or string output if no callback is given.

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -178,7 +178,7 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
             foreach ($extraVars as $key => $value){
                 $vars[] = sprintf('%s=%s', $key, $value);
             }
-            $this->addOption('--extra-vars', sprintf('"%s"', implode(' ', $vars)));
+            $this->addOption('--extra-vars', implode(' ', $vars));
             return $this;
         }
 
@@ -196,13 +196,6 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
         if (strpos($extraVars, '=') === false) {
             throw new InvalidArgumentException('The extra vars raw string should be in the "key=value" form.');
         }
-
-        // Here: we have a plain variable=value string
-        if (substr($extraVars, 0, 1) !== '"')
-            $extraVars = '"' . $extraVars;
-
-        if (substr($extraVars, -1, 1) !== '"')
-            $extraVars = $extraVars . '"';
 
         $this->addOption('--extra-vars', $extraVars);
         return $this;

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -165,34 +165,7 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
     }
 
     /**
-     * Sends extra variables to Ansible. The $extraVars parameter can be one of the following.
-     *
-     * ## Array
-     * If an array is passed, it must contain the [ 'key' => 'value' ] pairs of the variables.
-     *
-     * Example:
-     * ```php
-     * $ansible = new Ansible()->extraVars(['path' => 'some/path']);
-     * ```
-     *
-     * ## File
-     * As Ansible also supports extra vars loaded from an YML file, you can also pass a file path.
-     *
-     * Example:
-     * ```php
-     * $ansible = new Ansible()->extraVars('/path/to/extra/vars.yml');
-     * ```
-     *
-     * ## String
-     * You can also pass the raw extra vars string directly.
-
-     * Example:
-     * ```php
-     * $ansible = new Ansible()->extraVars('path=/some/path');
-     * ```
-     *
-     * @param string|array $extraVars
-     * @return AnsiblePlaybookInterface
+     * @inheritDoc
      */
     public function extraVars($extraVars=''): AnsiblePlaybookInterface
     {
@@ -281,6 +254,30 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
     public function inventoryFile(string $inventory = '/etc/ansible/hosts'): AnsiblePlaybookInterface
     {
         $this->addOption('--inventory-file', $inventory);
+        $this->hasInventory = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inventory(array $hosts = []): AnsiblePlaybookInterface
+    {
+        if (empty($hosts))
+            return $this;
+
+        // In order to let ansible-playbook understand that the given option is a list of hosts, the list must end by
+        // comma "," if it contains just an entry. For example, supposing just a single host, "localhosts":
+        //
+        //   Wrong: --inventory="locahost"
+        // Correct: --inventory="locahost,"
+        $hostList = implode(', ', $hosts);
+
+        if (count($hosts) === 1)
+            $hostList .= ',';
+
+        $this->addOption('--inventory', sprintf('"%s"', $hostList));
         $this->hasInventory = true;
 
         return $this;

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -664,6 +664,19 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
     }
 
     /**
+     * @inheritDoc
+     */
+    public function hostKeyChecking(bool $enable = true): AnsiblePlaybookInterface
+    {
+        $enable ?
+            $flag = 'True' :
+            $flag = 'False';
+
+        $this->processBuilder->setEnv('ANSIBLE_HOST_KEY_CHECKING', $flag);
+        return $this;
+    }
+
+    /**
      * If no inventory file is given, assume
      */
     private function checkInventory(): void

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -10,6 +10,8 @@
 
 namespace Asm\Ansible\Command;
 
+use InvalidArgumentException;
+
 /**
  * Class AnsiblePlaybook
  *
@@ -163,16 +165,73 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
     }
 
     /**
-     * Set additional variables as array [ 'key' => 'value' ] or string.
+     * Sends extra variables to Ansible. The $extraVars parameter can be one of the following.
+     *
+     * ## Array
+     * If an array is passed, it must contain the [ 'key' => 'value' ] pairs of the variables.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->extraVars(['path' => 'some/path']);
+     * ```
+     *
+     * ## File
+     * As Ansible also supports extra vars loaded from an YML file, you can also pass a file path.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->extraVars('/path/to/extra/vars.yml');
+     * ```
+     *
+     * ## String
+     * You can also pass the raw extra vars string directly.
+
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->extraVars('path=/some/path');
+     * ```
      *
      * @param string|array $extraVars
      * @return AnsiblePlaybookInterface
      */
-    public function extraVars($extraVars = ''): AnsiblePlaybookInterface
+    public function extraVars($extraVars=''): AnsiblePlaybookInterface
     {
-        $extraVars = $this->checkParam($extraVars, ' ');
-        $this->addOption('--extra-vars', $extraVars);
+        if (empty($extraVars))
+            return $this;
 
+        // Building the key=>value parameter
+        if (is_array($extraVars)){
+            $vars = [];
+            foreach ($extraVars as $key => $value){
+                $vars[] = sprintf('%s=%s', $key, $value);
+            }
+            $this->addOption('--extra-vars', sprintf('"%s"', implode(' ', $vars)));
+            return $this;
+        }
+
+        // Should we consider $extraVars as a JSON/YML file?
+        if (@is_file($extraVars)) {
+            $this->addOption('--extra-vars', sprintf('@"%s"', $extraVars));
+            return $this;
+        }
+
+        // At this point, the only allowed type is string.
+        if (!is_string($extraVars))
+            throw new InvalidArgumentException(sprintf('Expected string|array, got "%s"', gettype($extraVars)));
+
+
+        if (strpos($extraVars, '=') === false) {
+            throw new InvalidArgumentException('The extra vars raw string should be in the "key=value" form.');
+        }
+
+        // Here: we have a plain variable=value string
+        if (substr($extraVars, 0, 1) !== '"')
+            $extraVars = '"' . $extraVars;
+
+        if (substr($extraVars, -1, 1) !== '"')
+            $extraVars = $extraVars . '"';
+
+        $this->addOption('--extra-vars', $extraVars);
         return $this;
     }
 

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -649,6 +649,21 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
     }
 
     /**
+     * @inheritDoc
+     */
+    public function rolesPath(string $path): AnsiblePlaybookInterface
+    {
+        if (empty($path))
+            return $this;
+
+        if (!file_exists($path))
+            throw new InvalidArgumentException(sprintf('The path "%s" does not exist.', $path));
+
+        $this->processBuilder->setEnv('ANSIBLE_ROLES_PATH', $path);
+        return $this;
+    }
+
+    /**
      * If no inventory file is given, assume
      */
     private function checkInventory(): void

--- a/Asm/Ansible/Command/AnsiblePlaybookInterface.php
+++ b/Asm/Ansible/Command/AnsiblePlaybookInterface.php
@@ -385,4 +385,11 @@ interface AnsiblePlaybookInterface extends AnsibleCommandInterface
      * @return AnsiblePlaybookInterface
      */
     public function rolesPath(string $path): AnsiblePlaybookInterface;
+
+    /**
+     * Enables or disables the host's SSH key checking.
+     * @param bool $enable
+     * @return AnsiblePlaybookInterface
+     */
+    public function hostKeyChecking(bool $enable = true): AnsiblePlaybookInterface;
 }

--- a/Asm/Ansible/Command/AnsiblePlaybookInterface.php
+++ b/Asm/Ansible/Command/AnsiblePlaybookInterface.php
@@ -374,4 +374,15 @@ interface AnsiblePlaybookInterface extends AnsibleCommandInterface
      * @return AnsiblePlaybookInterface
      */
     public function version(): AnsiblePlaybookInterface;
+
+    /**
+     * Let you specify your custom roles path.
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->playbook()->rolesPath('/path/to/your/roles');
+     * ```
+     * @param string $path
+     * @return AnsiblePlaybookInterface
+     */
+    public function rolesPath(string $path): AnsiblePlaybookInterface;
 }

--- a/Asm/Ansible/Command/AnsiblePlaybookInterface.php
+++ b/Asm/Ansible/Command/AnsiblePlaybookInterface.php
@@ -94,8 +94,31 @@ interface AnsiblePlaybookInterface extends AnsibleCommandInterface
     public function diff(): AnsiblePlaybookInterface;
 
     /**
-     * Set additional variables as array [ 'key' => 'value' ] or string.
+     * Sends extra variables to Ansible. The $extraVars parameter can be one of the following.
      *
+     * ## Array
+     * If an array is passed, it must contain the [ 'key' => 'value' ] pairs of the variables.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->playbook()->extraVars(['path' => 'some/path']);
+     * ```
+     *
+     * ## File
+     * As Ansible also supports extra vars loaded from an YML file, you can also pass a file path.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->playbook()->extraVars('/path/to/extra/vars.yml');
+     * ```
+     *
+     * ## String
+     * You can also pass the raw extra vars string directly.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->playbook()->extraVars('path=/some/path');
+     * ```
      * @param string|array $extraVars
      * @return AnsiblePlaybookInterface
      */
@@ -137,6 +160,19 @@ interface AnsiblePlaybookInterface extends AnsibleCommandInterface
      * @return AnsiblePlaybookInterface
      */
     public function inventoryFile(string $inventory = '/etc/ansible/hosts'): AnsiblePlaybookInterface;
+
+    /**
+     * Specify inventory host list manually.
+     * Example:
+     *
+     * ```php
+     * $ansible = new Ansible()->playbook()->inventory(['localhost', 'host1.example.com']);
+     * ```
+     *
+     * @param array $hosts An array containing the list of hosts.
+     * @return AnsiblePlaybookInterface
+     */
+    public function inventory(array $hosts = []): AnsiblePlaybookInterface;
 
     /**
      * Further limit selected hosts to an additional pattern.

--- a/Asm/Ansible/Command/Option.php
+++ b/Asm/Ansible/Command/Option.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * This file is part of the php-ansible package.
+ *
+ * (c) Marc Aschmann <maschmann@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm\Ansible\Command;
+
+/**
+ * Class Option
+ * @package Asm\Ansible\Command
+ * @author  Metagûsto <opensource@metagusto.com>
+ */
+class Option
+{
+    /**
+     * @var string|null
+     */
+    protected $name = null;
+    /**
+     * @var string|null
+     */
+    protected $value = null;
+
+    /**
+     * Option constructor.
+     * @param string|null $name
+     * @param string|null $value
+     */
+    public function __construct(?string $name = null, ?string $value = null)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     */
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string|null $value
+     */
+    public function setValue(?string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('%s=%s', $this->name, $this->value);
+    }
+
+    /**
+     * Converts the option to string
+     * @return string
+     */
+    public function toString(): string
+    {
+        return $this->__toString();
+    }
+
+    /**
+     * @param Option|null $other
+     * @return bool
+     */
+    public function equals(?Option $other)
+    {
+        if ($other === null)
+            return false;
+
+        return $this->name === $other->getName() && $this->value === $other->value;
+    }
+
+}

--- a/Asm/Ansible/Exception/CommandException.php
+++ b/Asm/Ansible/Exception/CommandException.php
@@ -1,13 +1,15 @@
 <?php
 namespace Asm\Ansible\Exception;
 
+use RuntimeException;
+
 /**
  * Class CommandException
  *
  * @package Asm\Ansible\Exception
  * @author Marc Aschmann <maschmann@gmail.com>
  */
-class CommandException extends \RuntimeException
+class CommandException extends RuntimeException
 {
     protected $code = 500;
 }

--- a/Asm/Ansible/Process/ProcessBuilder.php
+++ b/Asm/Ansible/Process/ProcessBuilder.php
@@ -43,15 +43,14 @@ class ProcessBuilder implements ProcessBuilderInterface
     private $envVars;
 
     /**
-
      * ProcessBuilder constructor.
      *
-     * @param string $prefix
-     * @param string $path
+     * @param string $command The command to run.
+     * @param string $path The working directory.
      */
-    public function __construct(string $prefix, string $path)
+    public function __construct(string $command, string $path)
     {
-        $this->arguments = [$prefix];
+        $this->arguments = [$command];
         $this->path = $path;
         $this->timeout = 900;
         $this->envVars = [];

--- a/README.md
+++ b/README.md
@@ -3,48 +3,60 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/maschmann/php-ansible/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/maschmann/php-ansible/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/maschmann/php-ansible/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/maschmann/php-ansible/?branch=master)
 
-This library is a oop-wrapper for the ansible provisioning tool.
+This library is a OOP-wrapper for the ansible provisioning tool.
 I intend to use this library for a symfony2 bundle and also a deployment GUI, based on php/symfony2.
-The current implementation is feature-complete for ansible-playbook and ansible-galaxy
+The current implementation is feature-complete for the `ansible-playbook` and `ansible-galaxy` commands.
 
-Next steps for implementation are: wrapping the lib into a bundle and provide e.g. commandline-capabilities.
 
-## prerequisites
+
+## Prerequisites
 
 Your OS should be a flavor of linux and ansible has to be installed. It's easiest if ansible is in PATH :-)
 The library tries to find ansible-playbook and ansible-galaxy by itself or use the paths/executables you provide. 
 
-## usage
+
+
+## Usage
 
 First instantiate the base object which works as a factory for the commands.
-Only the first parameter is mandatory, and provides the library with the path to your ansible deployment file structure. The other two params are optional paths to your local ansible installation's binaries, in case they are not in PATH.
+Only the first parameter is mandatory, and provides the library with the path to your ansible deployment file structure. 
 
 ```php
-    $ansible = new Ansible(
-        '/path/to/ansible/deployment',
-        '/optional/path/to/ansible-playbook',
-        '/optional/path/to/ansible-galaxy'
-    );
+$ansible = new Ansible(
+    '/path/to/ansible/deployment'
+);
 ```
 
-### playbooks
+Optionally, you can specify the path of your `ansible-playbook` and `ansible-galaxy` commands, just in case they are not in the PATH.
+
+```php
+$ansible = new Ansible(
+    '/path/to/ansible/deployment',
+    '/optional/path/to/command/ansible-playbook',
+    '/optional/path/to/command/ansible-galaxy'
+);
+```
+
+
+
+### Playbooks
 
 Then you can use the object just like in your previous ansible deployment.
 If you don't specify an inventory file with ```->inventoryFile('filename')```, the wrapper tries to determine one, based on your playbook name: 
 
 ```php
-    $ansible
-        ->playbook()
-        ->play('mydeployment.yml') // based on deployment root 
-        ->user('maschmann')
-        ->extraVars(['project_release=20150514092022'])
-        ->limit('test')
-        ->execute();
+$ansible
+    ->playbook()
+    ->play('mydeployment.yml') // based on deployment root 
+    ->user('maschmann')
+    ->extraVars(['project_release' => 20150514092022])
+    ->limit('test')
+    ->execute();
 ```
 
 This will create following ansible command:
 
-```
+```bash
 $ ansible-playbook mydeployment.yml -i mydeployment --user=maschmann --extra-vars="project-release=20150514092022" --limit=test
 ```
 
@@ -52,77 +64,108 @@ $ ansible-playbook mydeployment.yml -i mydeployment --user=maschmann --extra-var
 For the execute command you can use a callback to get real-time output of the command:
 
 ```php
-    $ansible
-        ->playbook()
-        ->play('mydeployment.yml') // based on deployment root 
-        ->user('maschmann')
-        ->extraVars(['project_release=20150514092022'])
-        ->limit('test')
-        ->execute(function ($type, $buffer) {
-            if (Process::ERR === $type) {
-                echo 'ERR > '.$buffer;
-            } else {
-                echo 'OUT > '.$buffer;
-            }
-        });
+$ansible
+    ->playbook()
+    ->play('mydeployment.yml') // based on deployment root 
+    ->user('maschmann')
+    ->extraVars(['project_release' => 20150514092022])
+    ->limit('test')
+    ->execute(function ($type, $buffer) {
+        if (Process::ERR === $type) {
+            echo 'ERR > '.$buffer;
+        } else {
+            echo 'OUT > '.$buffer;
+        }
+    });
 ```
 If no callback is given, the method will return the ansible-playbook output as a string, so you can either ```echo``` or directly pipe it into a log/whatever.
 
-### galaxy
+You can also pass an external YML/JSON file as extraVars containing a complex data structure to be passed to Ansible:
+
+```php
+$ansible
+    ->playbook()
+    ->play('mydeployment.yml') // based on deployment root 
+    ->extraVars('/path/to/your/extra/vars/file.yml')
+    ->execute();
+```
+
+
+
+
+
+### Galaxy
 
 The syntax follows ansible's syntax with one deviation: list is a reserved keyword in php (array context) and
 therefore I had to rename it to "modulelist()".
 
 ```php
-    $ansible
-        ->galaxy()
-        ->init('my_role')
-        ->initPath('/tmp/my_path') // or default ansible roles path
-        ->execute();
+$ansible
+    ->galaxy()
+    ->init('my_role')
+    ->initPath('/tmp/my_path') // or default ansible roles path
+    ->execute();
 ```
 would generate:
 
-```
+```bash
 $ ansible-galaxy init my_role --init-path=/tmp/my_path
 ```
 
 You can access all galaxy commands:
 
- * init()
- * info()
- * install()
- * help()
- * modulelist() //list
- * remove()
+ * `init()`
+ * `info()`
+ * `install()`
+ * `help()`
+ * `modulelist()`
+ * `remove()`
 
 You can combine the calls with their possible arguments, though I don't have any logic preventing e.g. ```--force``` from being applied to e.g. info().
 
 Possible arguments/options:
 
- * initPath()
- * offline()
- * server()
- * force()
- * roleFile()
- * rolesPath()
- * ignoreErrors()
- * noDeps()
+ * `initPath()`
+ * `offline()`
+ * `server()`
+ * `force()`
+ * `roleFile()`
+ * `rolesPath()`
+ * `ignoreErrors()`
+ * `noDeps()`
 
-### process timeout
+
+
+### Process timeout
+
 Default process timeout is set to 300 seconds. If you need more time to execute your processes: Adjust the timeout :-) 
 
 ```php
-    $ansible
-        ->galaxy()
-        ->setTimeout(600)
-        ...
+$ansible
+    ->galaxy()
+    ->setTimeout(600)
+    …
 ```
 
-### thank you for your contributions!
+
+
+## Thank you for your contributions!
+
 thank you for reviewing, bug reporting, suggestions and PRs :-)
 [xabbuh](https://github.com/xabbuh), [emielmolenaar](https://github.com/emielmolenaar), [saverio](https://github.com/saverio), [soupdiver](https://github.com/soupdiver), [linaori](https://github.com/linaori), [paveldanilin](https://github.com/paveldanilin)
 
-license
+
+
+## Future features
+
+The Next steps for implementation are:
+
+-  wrapping the library into a bundle.
+- provide commandline-capabilities.
+
+
+
+License
 ----
 
 php-ansible is licensed under the MIT license. See the [LICENSE](LICENSE) for the full license text.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ $ansible = new Ansible(
 );
 ```
 
+You can also pass any PSR compliant logging class to have further details logged. This is **especially useful to have the actual run command logged**.
+
+```php
+$ansible = new Ansible(
+    '/path/to/ansible/deployment'
+);
+
+// $logger is a PSR-compliant logging implementation (e.g. monolog)
+$ansible->setLogger($logger);
+```
+
 
 
 ### Playbooks

--- a/Tests/Asm/Ansible/AnsibleTest.php
+++ b/Tests/Asm/Ansible/AnsibleTest.php
@@ -68,10 +68,11 @@ class AnsibleTest extends AnsibleTestCase
      */
     public function testAnsibleNoCommandGivenException()
     {
-        $this->markTestIncomplete();
-        new Ansible(
-            $this->getProjectUri()
-        );
+        // TODO: Not sure why the following command should give an error.
+        $this->assertTrue(true);
+        //        new Ansible(
+        //            $this->getProjectUri()
+        //        );
     }
 
     /**

--- a/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
+++ b/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
@@ -12,6 +12,7 @@ namespace Asm\Ansible\Command;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Asm\Ansible\Utils\Env;
+use Psr\Log\NullLogger;
 
 class AnsibleGalaxyTest extends AnsibleTestCase
 {

--- a/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
+++ b/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
@@ -9,8 +9,6 @@
  */
 namespace Asm\Ansible\Command;
 
-use Asm\Ansible\Command\AnsibleGalaxy;
-use Asm\Ansible\Command\AnsibleGalaxyInterface;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Asm\Ansible\Utils\Env;
@@ -36,8 +34,11 @@ class AnsibleGalaxyTest extends AnsibleTestCase
      */
     public function testExecute(AnsibleGalaxyInterface $command)
     {
-        if (Env::isWindows())
-            $this->markTestSkipped('Skipped on Windows');
+        // Skipped on Windows
+        if (Env::isWindows()) {
+            $this->assertTrue(true);
+            return;
+        }
 
         $command->execute();
 

--- a/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
+++ b/Tests/Asm/Ansible/Command/AnsibleGalaxyTest.php
@@ -12,7 +12,6 @@ namespace Asm\Ansible\Command;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Asm\Ansible\Utils\Env;
-use Psr\Log\NullLogger;
 
 class AnsibleGalaxyTest extends AnsibleTestCase
 {

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -870,9 +870,20 @@ class AnsiblePlaybookTest extends AnsibleTestCase
                 $this->fail(sprintf('Failing asserting that %s exception has been thrown', InvalidArgumentException::class));
             }
             catch (InvalidArgumentException $ignored) {
-
             }
         }
+
+        // Testing multiple params instances
+        // (see https://github.com/metagusto/php-ansible/issues/7)
+        // ------------------------------------------------------
+        $ansible = new AnsiblePlaybook($builder);
+        $ansible->extraVars(['key' => 'value']);
+        $ansible->extraVars($playbookFile);
+
+        // We should get:
+        $arguments = $ansible->getCommandlineArguments();
+        $this->assertTrue(in_array('--extra-vars="key=value"', $arguments));
+        $this->assertTrue(in_array(sprintf('--extra-vars=@"%s"', $playbookFile), $arguments));
     }
 
     public function testInventory()

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -963,4 +963,32 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         $this->expectException(InvalidArgumentException::class);
         $ansible->rolesPath('/really/not/existing/path');
     }
+
+    public function testHostKeyChecking()
+    {
+        $tests = [
+            [
+                'input' => true,
+                'expect' => 'True',
+            ],
+            [
+                'input' => false,
+                'expect' => 'False',
+            ],
+        ];
+
+        $builder = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        foreach ($tests as $test) {
+
+            $input = $test['input'];
+            $expect = $test['expect'];
+
+            $ansible = new AnsiblePlaybook($builder);
+            $ansible->hostKeyChecking($input);
+            $env = $builder->getProcess()->getEnv();
+
+            $this->assertArrayHasKey('ANSIBLE_HOST_KEY_CHECKING', $env);
+            $this->assertEquals($expect, $env['ANSIBLE_HOST_KEY_CHECKING']);
+        }
+    }
 }

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -834,6 +834,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
         foreach ($tests as $test) {
+
             $input = $test['input'];
             $expect = $test['expect'];
 
@@ -871,6 +872,44 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             catch (InvalidArgumentException $ignored) {
 
             }
+        }
+    }
+
+    public function testInventory()
+    {
+        $tests = [
+            [
+                'input' => [],
+                'expect' => false,
+            ],
+            [
+                'input' => ['localhost'],
+                'expect' => '--inventory="localhost,"',
+            ],
+            [
+                'input' => ['localhost', 'host1'],
+                'expect' => '--inventory="localhost, host1"',
+            ],
+
+        ];
+
+        $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        foreach ($tests as $test) {
+
+            $input = $test['input'];
+            $expect = $test['expect'];
+
+            $ansible = new AnsiblePlaybook($process);
+            $ansible->inventory($input);
+            $arguments = array_flip($ansible->getCommandlineArguments());
+
+            // Handles cases when the --inventory params should be missing.
+            if ($expect === false) {
+                $this->assertArrayNotHasKey('--inventory', $arguments);
+                continue;
+            }
+
+            $this->assertArrayHasKey($expect, $arguments);
         }
     }
 

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -815,15 +815,15 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             ],
             [
                 'input' => ['key' => 'value'],
-                'expect' => '--extra-vars="key=value"',
+                'expect' => '--extra-vars=key=value',
             ],
             [
                 'input' => ['key1' => 'value1', 'key2' => 'value2'],
-                'expect' => '--extra-vars="key1=value1 key2=value2"',
+                'expect' => '--extra-vars=key1=value1 key2=value2',
             ],
             [
                 'input' => 'key=value',
-                'expect' => '--extra-vars="key=value"',
+                'expect' => '--extra-vars=key=value',
             ],
             [
                 'input' => $playbookFile,
@@ -882,7 +882,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         // We should get:
         $arguments = $ansible->getCommandlineArguments();
-        $this->assertTrue(in_array('--extra-vars="key=value"', $arguments));
+        $this->assertTrue(in_array('--extra-vars=key=value', $arguments));
         $this->assertTrue(in_array(sprintf('--extra-vars=@"%s"', $playbookFile), $arguments));
     }
 

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -12,6 +12,9 @@ namespace Asm\Ansible\Command;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Asm\Ansible\Utils\Env;
+use DateTime;
+use Exception;
+use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 
 class AnsiblePlaybookTest extends AnsibleTestCase
@@ -24,7 +27,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
         $ansible = new AnsiblePlaybook($process);
 
-        $this->assertInstanceOf('\Asm\Ansible\Command\AnsiblePlaybook', $ansible);
+        $this->assertInstanceOf(AnsiblePlaybook::class, $ansible);
 
         return $ansible;
     }
@@ -33,11 +36,11 @@ class AnsiblePlaybookTest extends AnsibleTestCase
      * @depends testCreateInstance
      * @param AnsiblePlaybookInterface $command
      * @return AnsiblePlaybookInterface
-     * @throws \Exception
+     * @throws Exception
      */
     public function testDefaultDeployment(AnsiblePlaybookInterface $command)
     {
-        $today = new \DateTime();
+        $today = new DateTime();
 
         $command
             ->play($this->getPlayUri())
@@ -654,7 +657,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         $arguments = array_flip($command->getCommandlineArguments());
         $this->assertArrayHasKey('--new-vault-password-file=/path/to/vault', $arguments);
 
-        return $command;;
+        return $command;
     }
 
     /**
@@ -765,8 +768,11 @@ class AnsiblePlaybookTest extends AnsibleTestCase
      */
     public function testExecuteWithCallback(AnsiblePlaybookInterface $command)
     {
-        if (Env::isWindows())
-            $this->markTestSkipped('Skipped on Windows');
+        // Skipped on Windows
+        if (Env::isWindows()) {
+            $this->assertTrue(true);
+            return;
+        }
 
         $exitcode = $command
             ->execute(function ($type, $buffer) {
@@ -775,6 +781,8 @@ class AnsiblePlaybookTest extends AnsibleTestCase
                 } else {
                     $out = 'OUT > '.$buffer;
                 }
+                // Silly assert, just to remove the unused warning.
+                $this->assertNotNull($out);
             });
 
         $this->assertTrue(is_integer($exitcode));
@@ -790,6 +798,80 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             ->execute(null);
 
         $this->assertTrue(is_string($result));
+    }
+
+    public function testExtraVars()
+    {
+        $playbookFile = $this->getSamplesPathFor(AnsiblePlaybook::class) . '/playbook1.yml';
+
+        $tests = [
+            [
+                'input' => '',
+                'expect' => false,
+            ],
+            [
+                'input' => [],
+                'expect' => false,
+            ],
+            [
+                'input' => ['key' => 'value'],
+                'expect' => '--extra-vars="key=value"',
+            ],
+            [
+                'input' => ['key1' => 'value1', 'key2' => 'value2'],
+                'expect' => '--extra-vars="key1=value1 key2=value2"',
+            ],
+            [
+                'input' => 'key=value',
+                'expect' => '--extra-vars="key=value"',
+            ],
+            [
+                'input' => $playbookFile,
+                'expect' => sprintf('--extra-vars=@"%s"', $playbookFile),
+            ],
+        ];
+
+
+        $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        foreach ($tests as $test) {
+            $input = $test['input'];
+            $expect = $test['expect'];
+
+            $ansible = new AnsiblePlaybook($process);
+            $ansible->extraVars($input);
+            $arguments = array_flip($ansible->getCommandlineArguments());
+
+            // Handles cases when the --extra-vars params should be missing.
+            if ($expect === false) {
+                $this->assertArrayNotHasKey('--extra-vars', $arguments);
+                continue;
+            }
+
+            $this->assertArrayHasKey($expect, $arguments);
+        }
+
+
+        // Testing exceptions
+        // ------------------
+        // The following tests should throw an InvalidArgumentException
+
+        $tests = [
+            'string without equals',
+            new DateTime()
+        ];
+
+        foreach ($tests as $input) {
+            try {
+                $ansible = new AnsiblePlaybook($process);
+                $ansible->extraVars($input);
+
+                // We should never reach this line!
+                $this->fail(sprintf('Failing asserting that %s exception has been thrown', InvalidArgumentException::class));
+            }
+            catch (InvalidArgumentException $ignored) {
+
+            }
+        }
     }
 
 }

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -832,13 +832,13 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         ];
 
 
-        $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        $builder = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
         foreach ($tests as $test) {
 
             $input = $test['input'];
             $expect = $test['expect'];
 
-            $ansible = new AnsiblePlaybook($process);
+            $ansible = new AnsiblePlaybook($builder);
             $ansible->extraVars($input);
             $arguments = array_flip($ansible->getCommandlineArguments());
 
@@ -863,7 +863,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         foreach ($tests as $input) {
             try {
-                $ansible = new AnsiblePlaybook($process);
+                $ansible = new AnsiblePlaybook($builder);
                 $ansible->extraVars($input);
 
                 // We should never reach this line!
@@ -893,13 +893,13 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         ];
 
-        $process = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        $builder = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
         foreach ($tests as $test) {
 
             $input = $test['input'];
             $expect = $test['expect'];
 
-            $ansible = new AnsiblePlaybook($process);
+            $ansible = new AnsiblePlaybook($builder);
             $ansible->inventory($input);
             $arguments = array_flip($ansible->getCommandlineArguments());
 
@@ -913,4 +913,43 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         }
     }
 
+    public function testRolesPath()
+    {
+        $samplePath = $this->getSamplesPathFor(AnsiblePlaybook::class);
+        $tests = [
+            [
+                'input' => '',
+                'expect' => false,
+            ],
+            [
+                'input' => $samplePath,
+                'expect' => $samplePath,
+            ],
+        ];
+
+        $ansible = null;
+        $builder = new ProcessBuilder($this->getPlaybookUri(), $this->getProjectUri());
+        foreach ($tests as $test) {
+
+            $input = $test['input'];
+            $expect = $test['expect'];
+
+            $ansible = new AnsiblePlaybook($builder);
+            $ansible->rolesPath($input);
+            $env = $builder->getProcess()->getEnv();
+
+            // Handles cases when the ANSIBLE_ROLES_PATH var should be missing.
+            if ($expect === false) {
+                $this->assertArrayNotHasKey('ANSIBLE_ROLES_PATH', $env);
+                continue;
+            }
+
+            $this->assertArrayHasKey('ANSIBLE_ROLES_PATH', $env);
+            $this->assertEquals($expect, $env['ANSIBLE_ROLES_PATH']);
+        }
+
+        // Ensuring that the InvalidArgumentException is thrown
+        $this->expectException(InvalidArgumentException::class);
+        $ansible->rolesPath('/really/not/existing/path');
+    }
 }

--- a/Tests/Asm/Ansible/Command/OptionTest.php
+++ b/Tests/Asm/Ansible/Command/OptionTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) 2016 Metagûsto <info@metagusto.com>
+ */
+
+namespace Asm\Ansible\Command;
+
+use PHPUnit\Framework\TestCase;
+
+class OptionTest extends TestCase
+{
+    public function testInstance()
+    {
+        $option = new Option('name', 'value');
+        $this->assertEquals('name', $option->getName());
+        $this->assertEquals('value', $option->getValue());
+
+        $this->assertTrue($option->equals(new Option('name', 'value')));
+        $this->assertFalse($option->equals(null));
+        $this->assertEquals('name=value', $option->toString());
+        $this->assertEquals('name=value', (string)$option);
+
+        $option->setName('_name');
+        $option->setValue('_value');
+        $this->assertEquals('_name', $option->getName());
+        $this->assertEquals('_value', $option->getValue());
+    }
+
+
+}

--- a/Tests/Asm/Ansible/Process/ProcessBuilderTest.php
+++ b/Tests/Asm/Ansible/Process/ProcessBuilderTest.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Asm\Ansible\Process;
 
-use Asm\Ansible\Process\ProcessBuilder;
-use Asm\Ansible\Process\ProcessBuilderInterface;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Symfony\Component\Process\Process;
 

--- a/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
+++ b/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
@@ -44,7 +44,7 @@ abstract class AnsibleTestCase extends TestCase
     /**
      * default setup
      */
-    protected function setUp()
+    protected function setUp():void
     {
         $this->createProjectStructure();
     }

--- a/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
+++ b/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
@@ -194,4 +194,35 @@ EOT;
         return implode('/', [$this->getAssetsPath(), 'bin']);
     }
 
+    /**
+     * Returns the assets path.
+     * @return string
+     */
+    protected function getSamplesPath(): string
+    {
+        return implode('/', [$this->getAssetsPath(), 'samples']);
+    }
+
+    /**
+     * Returns the assets path for a given class.
+     *
+     * Example:
+     * ```php
+     * $path = $this->getSamplesPathFor(Ansible::class);
+     *
+     * // Returns
+     * // /your/project/pathTests/samples/Asm/Ansible
+     * ```
+     *
+     * @param string $class The class FQN. E.g. Asm\Ansibe\Ansible
+     * @return string
+     */
+    protected function getSamplesPathFor(string $class): string
+    {
+        return implode('/', [$this->getSamplesPath(), str_replace('\\', '/', $class)]);
+    }
+
+
+
+
 }

--- a/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
+++ b/Tests/Asm/Ansible/Testing/AnsibleTestCase.php
@@ -221,8 +221,4 @@ EOT;
     {
         return implode('/', [$this->getSamplesPath(), str_replace('\\', '/', $class)]);
     }
-
-
-
-
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^9.0",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "asm/php-ansible",
-    "description": "php wrapper for ansible commands",
+    "description": "A PHP wrapper for Ansible.",
+    "version": "2.0.1-dev",
     "keywords": [
         "php",
         "ansible"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.0",
+        "psr/log": "^1.1",
         "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,55 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3212be45394508fe75bc57813dc41fd1",
+    "content-hash": "933322fcb6445bac945149ad86978d3d",
     "packages": [
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
+        },
         {
             "name": "symfony/process",
             "version": "v5.0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1610 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8e28e115a603dc69b4ce2c16e8cef57a",
+    "packages": [
+        {
+            "name": "symfony/process",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-15T15:59:10+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-10-30T15:31:00+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2020-04-27T09:25:28+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-22T12:28:44+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-10-31T16:06:48+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2018-09-13T20:33:42+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2019-06-07T04:22:29+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2019-09-17T06:23:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.5.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-01-08T08:45:45+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-07-12T15:12:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2019-02-04T06:01:07+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2019-11-20T08:46:58+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2019-09-14T09:02:43+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T16:14:59+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2020-04-18T12:12:48+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.1.0"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e28e115a603dc69b4ce2c16e8cef57a",
+    "content-hash": "3212be45394508fe75bc57813dc41fd1",
     "packages": [
         {
             "name": "symfony/process",
@@ -536,40 +536,41 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^7.3",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-token-stream": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^2.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/version": "^3.0",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "8.0-dev"
                 }
             },
             "autoload": {
@@ -595,32 +596,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2020-02-19T13:41:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "4ac5b3e13df14829daa60a2eb4fdd2f2b7d33cf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4ac5b3e13df14829daa60a2eb4fdd2f2b7d33cf4",
+                "reference": "4ac5b3e13df14829daa60a2eb4fdd2f2b7d33cf4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -645,26 +646,90 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-18T05:02:12+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-02-07T06:06:11+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -686,32 +751,32 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2020-02-01T07:43:44+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "dc9368fae6ef2ffa57eba80a7410bcef81df6258"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/dc9368fae6ef2ffa57eba80a7410bcef81df6258",
+                "reference": "dc9368fae6ef2ffa57eba80a7410bcef81df6258",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -735,33 +800,39 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-20T06:00:37+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "cdc0db5aed8fbfaf475fbd95bfd7bab83c7a779c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/cdc0db5aed8fbfaf475fbd95bfd7bab83c7a779c",
+                "reference": "cdc0db5aed8fbfaf475fbd95bfd7bab83c7a779c",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -784,57 +855,64 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-09-17T06:23:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-05-06T09:56:31+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "9.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "2d7080c622cf7884992e7c3cf87853877bae8ff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2d7080c622cf7884992e7c3cf87853877bae8ff4",
+                "reference": "2d7080c622cf7884992e7c3cf87853877bae8ff4",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.3",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^8.0.1",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-invoker": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-timer": "^3.1.4",
+                "sebastian/code-unit": "^1.0.2",
+                "sebastian/comparator": "^4.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/environment": "^5.0.1",
+                "sebastian/exporter": "^4.0",
+                "sebastian/global-state": "^4.0",
+                "sebastian/object-enumerator": "^4.0",
+                "sebastian/resource-operations": "^3.0",
+                "sebastian/type": "^2.0",
+                "sebastian/version": "^3.0"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -842,12 +920,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "9.1-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -868,32 +949,94 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-30T06:32:53+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "name": "sebastian/code-unit",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "ac958085bc19fcd1d36425c781ef4cbb5b06e2a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/ac958085bc19fcd1d36425c781ef4cbb5b06e2a5",
+                "reference": "ac958085bc19fcd1d36425c781ef4cbb5b06e2a5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-30T05:58:10+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -913,34 +1056,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2020-02-07T06:20:13+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": "^7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -953,6 +1096,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -964,10 +1111,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -977,33 +1120,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "time": "2020-02-07T06:08:51+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "3e523c576f29dacecff309f35e4cc5a5c168e78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3e523c576f29dacecff309f35e4cc5a5c168e78a",
+                "reference": "3e523c576f29dacecff309f35e4cc5a5c168e78a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1017,12 +1160,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -1033,27 +1176,33 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-05-08T05:01:12+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "c753f04d68cd489b6973cf9b4e505e191af3b05c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/c753f04d68cd489b6973cf9b4e505e191af3b05c",
+                "reference": "c753f04d68cd489b6973cf9b4e505e191af3b05c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1061,7 +1210,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1086,34 +1235,40 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-14T13:36:52+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "80c26562e964016538f832f305b2286e1ec29566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1153,27 +1308,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "time": "2020-02-07T06:10:52+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1181,7 +1339,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1204,34 +1362,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2020-02-07T06:11:37+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67516b175550abad905dc952f43285957ef4363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
+                "reference": "e67516b175550abad905dc952f43285957ef4363",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1251,122 +1409,27 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2020-02-07T06:12:23+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
@@ -1389,31 +1452,175 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-02-07T06:19:40+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/recursion-context",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-02-07T06:18:20+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2020-02-07T06:13:02+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2020-02-07T06:13:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1434,7 +1641,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2020-01-21T06:36:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
There are some cases where the way php-ansible is currently building the commandline is buggy and does not work. 

## Step to reproduce
Considering the following `ansible-playbook` command:

```bash
ansible-playbook playbooks/some-playbook.yml      \
                 --extra-vars="key=value"         \
                 --inventory="localhost,"         \
                 --connection=local
```

If generated via the php-ansible wrapper, the final commandline looks like
```bash
'ansible-playbook' 'playbooks/some-playbook.yml'  \
                   '--extra-vars="key=value"'     \
                   '--inventory="localhost,"'     \
                   '--connection=local'
```

The single quotes are puzzling Ansible making the `key` variable undefined at runtime:

```perl
ok: [localhost] => {
    "key": "VARIABLE IS NOT DEFINED!: 'key' is undefined"
}
```

## Solution
As Symfony Process is adding single quotes, we just don't need adding the double quotes for parameters like `--extra-vars` so the following:

```bash
 '--extra-vars="key=value"'
```
should just be:

```bash
 '--extra-vars=key=value'
```