### PR TITLE
Add Ansible SSH pipelining option

### DIFF
--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -716,6 +716,22 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
         $this->processBuilder->setEnv('ANSIBLE_HOST_KEY_CHECKING', $flag);
         return $this;
     }
+    
+    /**
+    * Ansible SSH pipelining option
+    * https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining
+    *
+    * @param bool $enable
+    **/
+    public function sshPipelining(bool $enable = false): AnsiblePlaybookInterface
+    {
+        $enable ?
+            $flag = 'True' :
+            $flag = 'False';
+
+        $this->processBuilder->setEnv('ANSIBLE_SSH_PIPELINING', $flag);
+        return $this;
+    }
 
     /**
      * If no inventory file is given, assume


### PR DESCRIPTION
Pipelining, if supported by the connection plugin, reduces the number of network operations required to execute a module on the remote server, by executing many Ansible modules without actual file transfer. This can result in a very significant performance improvement when enabled. However this conflicts with privilege escalation (become). For example, when using ‘sudo:’ operations you must first disable ‘requiretty’ in /etc/sudoers on all managed hosts, which is why it is disabled by default. 

- https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining