### PR TITLE
Updates requires versions for psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.0.0|^8.1.0|^8.2.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/process": "^5.3|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #81 

@maschmann 

- allow all psr/log versions to be used. methods & interface/traits do not change between versions
- Ran all tests locally on PHP version 8.1 & they were all successful


`Psr\LogLoggerAwareTrait` (and it's `setLogger` method) exist in all three `psr/log` versions
- [v1](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/LoggerAwareTrait.php)
- [v2](https://github.com/php-fig/log/blob/2.0.0/src/LoggerAwareTrait.php)
- [v3](https://github.com/php-fig/log/blob/3.0.0/src/LoggerAwareTrait.php)


`Psr\Log\LoggerInterface`
- [v1](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/LoggerInterface.php)
- [v2](https://github.com/php-fig/log/blob/2.0.0/src/LoggerInterface.php)
- [v3](https://github.com/php-fig/log/blob/3.0.0/src/LoggerInterface.php)


`Psr\Log\NullLogger`
- [v1](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/NullLogger.php)
- [v2](https://github.com/php-fig/log/blob/2.0.0/src/NullLogger.php)
- [v3](https://github.com/php-fig/log/blob/3.0.0/src/NullLogger.php)


`Psr\Log\LoggerAwareInterface`
- [v1](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/LoggerAwareInterface.php)
- [v2](https://github.com/php-fig/log/blob/2.0.0/src/LoggerAwareInterface.php)
- [v3](https://github.com/php-fig/log/blob/3.0.0/src/LoggerAwareInterface.php)