### PR TITLE
Allow JSON Format Ansible --extra-vars

### DIFF
--- a/Asm/Ansible/Ansible.php
+++ b/Asm/Ansible/Ansible.php
@@ -12,7 +12,6 @@ use Asm\Ansible\Exception\CommandException;
 use Asm\Ansible\Process\ProcessBuilder;
 use Asm\Ansible\Process\ProcessBuilderInterface;
 use Asm\Ansible\Utils\Env;
-use JetBrains\PhpStorm\Pure;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Asm\Ansible\Command;
 
+use Asm\Ansible\Utils\Str;
 use InvalidArgumentException;
+use JsonException;
 
 /**
  * Class AnsiblePlaybook
@@ -208,6 +210,20 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
         // At this point, the only allowed type is string.
         if (!is_string($extraVars)) {
             throw new InvalidArgumentException(sprintf('Expected string|array, got "%s"', gettype($extraVars)));
+        }
+
+        // Trim the string & check if empty before moving on.
+        $extraVars = trim($extraVars);
+
+        if ($extraVars === '') {
+            return $this;
+        }
+
+        // JSON formatted string can be used for extra vars as is, wrap around single quotes.
+        if (Str::isJsonFormatted($extraVars)) {
+            $this->addOption('--extra-vars', '\'' . Str::escapeSingleQuotes($extraVars) . '\'');
+
+            return $this;
         }
 
         if (!str_contains($extraVars, '=')) {

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -219,9 +219,10 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
             return $this;
         }
 
-        // JSON formatted string can be used for extra vars as is, wrap around single quotes.
+        // JSON formatted string can be used for extra vars as is.
+        // The value is automatically escaped & wrapped around single quotes from the Library's process.
         if (Str::isJsonFormatted($extraVars)) {
-            $this->addOption('--extra-vars', '\'' . Str::escapeSingleQuotes($extraVars) . '\'');
+            $this->addOption('--extra-vars', $extraVars);
 
             return $this;
         }

--- a/Asm/Ansible/Utils/Str.php
+++ b/Asm/Ansible/Utils/Str.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Asm\Ansible\Utils;
+
+use JsonException;
+
+class Str
+{
+    /**
+     * Validate the provided string is JSON formatted.
+     *
+     * Not JSON if result is not an object (stdClass).
+     * Silent return false on exceptions e.g. Invalid/Incorrect encoding, Array depth more than 512 etc.
+     *
+     * @param string $value
+     * @return bool
+     */
+    public static function isJsonFormatted(string $value): bool
+    {
+        try {
+            return is_object(json_decode($value, false, 512, JSON_THROW_ON_ERROR));
+        } catch (JsonException) {
+            return false;
+        }
+    }
+
+    /**
+     * Escape single quotes.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function escapeSingleQuotes(string $value): string
+    {
+        return str_replace("'", "\'", $value);
+    }
+}

--- a/Asm/Ansible/Utils/Str.php
+++ b/Asm/Ansible/Utils/Str.php
@@ -25,15 +25,4 @@ class Str
             return false;
         }
     }
-
-    /**
-     * Escape single quotes.
-     *
-     * @param string $value
-     * @return string
-     */
-    public static function escapeSingleQuotes(string $value): string
-    {
-        return str_replace("'", "\'", $value);
-    }
 }

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -827,12 +827,7 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             // Test valid JSON.
             [
                 'input' => '{ "key1": "value1", "key2": "value2" }',
-                'expect' => '--extra-vars=\'{ "key1": "value1", "key2": "value2" }\'',
-            ],
-            // Test valid JSON with single quotes escaped.
-            [
-                'input' => '{ "key1": "va\'lue1", "key2": "va\'lue2" }',
-                'expect' => '--extra-vars=\'{ "key1": "va\\\'lue1", "key2": "va\\\'lue2" }\'',
+                'expect' => '--extra-vars={ "key1": "value1", "key2": "value2" }',
             ],
             // Test key value string.
             [

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -801,14 +801,21 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         //$playbookFile = $this->getSamplesPathFor(AnsiblePlaybook::class) . '/playbook1.yml';
 
         $tests = [
+            // Test empty strings (with & without spaces).
             [
                 'input' => '',
                 'expect' => false,
             ],
             [
+                'input' => '   ',
+                'expect' => false,
+            ],
+            // Test empty array.
+            [
                 'input' => [],
                 'expect' => false,
             ],
+            // Test Arrays
             [
                 'input' => ['key' => 'value'],
                 'expect' => '--extra-vars=key=value',
@@ -817,6 +824,17 @@ class AnsiblePlaybookTest extends AnsibleTestCase
                 'input' => ['key1' => 'value1', 'key2' => 'value2'],
                 'expect' => '--extra-vars=key1=value1 key2=value2',
             ],
+            // Test valid JSON.
+            [
+                'input' => '{ "key1": "value1", "key2": "value2" }',
+                'expect' => '--extra-vars=\'{ "key1": "value1", "key2": "value2" }\'',
+            ],
+            // Test valid JSON with single quotes escaped.
+            [
+                'input' => '{ "key1": "va\'lue1", "key2": "va\'lue2" }',
+                'expect' => '--extra-vars=\'{ "key1": "va\\\'lue1", "key2": "va\\\'lue2" }\'',
+            ],
+            // Test key value string.
             [
                 'input' => 'key=value',
                 'expect' => '--extra-vars=key=value',
@@ -854,7 +872,8 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         $tests = [
             'string without equals',
-            new DateTime()
+            '{ key1: "value1" }', // Invalid JSON syntax (missing " from key1) which would trigger string without `=`.
+            new DateTime() // Invalid type
         ];
 
         foreach ($tests as $input) {

--- a/Tests/Asm/Ansible/Utils/StrTest.php
+++ b/Tests/Asm/Ansible/Utils/StrTest.php
@@ -34,16 +34,4 @@ class StrTest extends TestCase
 
         $this->assertFalse(Str::isJsonFormatted($value));
     }
-
-    /**
-     * Assert single quotes are properly escaped.
-     *
-     * @return void
-     */
-    public function testSingleQuotesEscaped(): void
-    {
-        $value = "O'What";
-
-        $this->assertEquals("O\'What", Str::escapeSingleQuotes($value));
-    }
 }

--- a/Tests/Asm/Ansible/Utils/StrTest.php
+++ b/Tests/Asm/Ansible/Utils/StrTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Asm\Ansible\Utils;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group utils
+ */
+class StrTest extends TestCase
+{
+    /**
+     * Assert valid JSON string is correctly checked.
+     *
+     * @return void
+     */
+    public function testJsonWithValidFormat(): void
+    {
+        $value = '{ "key1": "value1" }';
+
+        $this->assertTrue(Str::isJsonFormatted($value));
+    }
+
+    /**
+     * Assert string is not valid JSON.
+     *
+     * @return void
+     */
+    public function testStringIsNotJson(): void
+    {
+        $value = 'something';
+
+        $this->assertFalse(Str::isJsonFormatted($value));
+    }
+
+    /**
+     * Assert single quotes are properly escaped.
+     *
+     * @return void
+     */
+    public function testSingleQuotesEscaped(): void
+    {
+        $value = "O'What";
+
+        $this->assertEquals("O\'What", Str::escapeSingleQuotes($value));
+    }
+}


### PR DESCRIPTION
- Removes a redundant import
- Allows for JSON formated `extraVars` option
- Adds Str utils (was considering a Trait, but following the library's approach) that allows to check for valid JSON format
- Added tests for positive & negative scenarios
- No escaping handled as this is done via the Symfony process library on execution.

Closes #85 