### PR TITLE
Fix error output if no callback is provided

### DIFF
--- a/Asm/Ansible/Command/AbstractAnsibleCommand.php
+++ b/Asm/Ansible/Command/AbstractAnsibleCommand.php
@@ -176,16 +176,18 @@ abstract class AbstractAnsibleCommand
         // exit code
         $result = $process->run($callback);
 
-        // text-mode
-        if (null === $callback) {
-            $result = $process->getOutput();
-
-            if (false === $process->isSuccessful()) {
-                $process->getErrorOutput();
-            }
+        // if a callback is set, we return the exit code
+        if (null !== $callback) {
+            return $result;
         }
 
-        return $result;
+        // if no callback is set, and the process is not successful, we return the output
+        if (false === $process->isSuccessful()) {
+            return $process->getErrorOutput();
+        }
+
+        // if no callback is set, and the process is successful, we return the output
+        return $process->getOutput();
     }
 
     /**

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -6,7 +6,6 @@ namespace Asm\Ansible\Command;
 
 use Asm\Ansible\Utils\Str;
 use InvalidArgumentException;
-use JsonException;
 
 /**
  * Class AnsiblePlaybook


### PR DESCRIPTION
This PR fixes the error output if no callback is provided.

Instead of nesting if conditions I went for a early return approach. I also provided a unit test for the cases.

If you want me to change anything, just drop a line :) 