### PR TITLE
Add quotes around each host in inventory

### DIFF
--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -276,7 +276,7 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
             $hostList .= ',';
         }
 
-        $this->addOption('--inventory', sprintf('"%s"', $hostList));
+        $this->addOption('--inventory', $hostList);
         $this->hasInventory = true;
 
         return $this;

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -289,7 +289,7 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
         //
         //   Wrong: --inventory="locahost"
         // Correct: --inventory="locahost,"
-        $hostList = implode(', ', $hosts);
+        $hostList = implode(',', $hosts);
 
         if (count($hosts) === 1) {
             $hostList .= ',';

--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -265,6 +265,9 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
             return $this;
         }
 
+        // Wrapping each host in double quotes to avoid issues with spaces in host names.
+        $hosts = array_map(fn ($host) => sprintf('"%s"', $host), $hosts);
+
         // In order to let ansible-playbook understand that the given option is a list of hosts, the list must end by
         // comma "," if it contains just an entry. For example, supposing just a single host, "localhosts":
         //

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -901,11 +901,11 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             ],
             [
                 'input' => ['localhost'],
-                'expect' => '--inventory="localhost,"',
+                'expect' => '--inventory="localhost",',
             ],
             [
                 'input' => ['localhost', 'host1'],
-                'expect' => '--inventory="localhost, host1"',
+                'expect' => '--inventory="localhost","host1"',
             ],
 
         ];
@@ -1117,12 +1117,4 @@ class AnsiblePlaybookTest extends AnsibleTestCase
 
         self::assertEquals(0, $playbook->execute(fn () => null));
     }
-    
-    public function testItWrapsTheHostsInQuotes(): void
-    {
-        $ansible = new AnsiblePlaybook($this->createMock(ProcessBuilderInterface::class));
-        $ansible->inventory(['host1', 'host 2']);
-
-        self::assertContains('--inventory="host1", "host 2"', $ansible->getCommandlineArguments());
-    }        
 }

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Asm\Ansible\Command;
 
 use Asm\Ansible\Process\ProcessBuilder;
+use Asm\Ansible\Process\ProcessBuilderInterface;
 use Asm\Ansible\Testing\AnsibleTestCase;
 use Asm\Ansible\Utils\Env;
 use DateTime;
@@ -1022,5 +1023,13 @@ class AnsiblePlaybookTest extends AnsibleTestCase
             $this->assertArrayHasKey('ANSIBLE_SSH_PIPELINING', $env);
             $this->assertEquals($expect, $env['ANSIBLE_SSH_PIPELINING']);
         }
+    }
+
+    public function testItWrapsTheHostsInQuotes(): void
+    {
+        $ansible = new AnsiblePlaybook($this->createMock(ProcessBuilderInterface::class));
+        $ansible->inventory(['host1', 'host 2']);
+
+        self::assertContains('--inventory="host1", "host 2"', $ansible->getCommandlineArguments());
     }
 }


### PR DESCRIPTION
This PR "fixes" how the inventory is parsed. 

Before it has surrounded the comma delimited hosts with double quotes. 
For me this ended up in something like:
```
ANSIBLE_HOST_KEY_CHECKING='False' 'ansible-playbook' 'general.yml' '--private-key=/Users/user_name/Projects/private/server/storage/app/ssh_keys/01GZ920GJKRZTWQ6DBD0Z623FN' '--user=user_name' '--inventory="111.92.169.113,"'
```
But  Ansible can't connect to the host by having  it formatted like this.
Adding quotes arounf each host resolves the issue for me:
```
ANSIBLE_HOST_KEY_CHECKING='False' 'ansible-playbook' 'general.yml' '--private-key=/Users/user_name/Projects/private/server/storage/app/ssh_keys/01GZ920GJKRZTWQ6DBD0Z623FN' '--user=user_name' '--inventory="111.92.169.113",'
```

~~This could be an issue for host names with spaces in it, or what do you think?~~

I changed it to wrap each host with quotes. I think this should solve both cases :) 