### PR TITLE
Restore --extra-var JSON string tests

### DIFF
--- a/Asm/Ansible/Command/AnsiblePlaybook.php
+++ b/Asm/Ansible/Command/AnsiblePlaybook.php
@@ -181,10 +181,18 @@ final class AnsiblePlaybook extends AbstractAnsibleCommand implements AnsiblePla
      *
      * ## String
      * You can also pass the raw extra vars string directly.
-
+     *
      * Example:
      * ```php
      * $ansible = new Ansible()->playbook()->extraVars('path=/some/path');
+     * ```
+     *
+     * ## JSON String
+     * You can also use a JSON string to pass the key/value pairs of extra vars.
+     *
+     * Example:
+     * ```php
+     * $ansible = new Ansible()->playbook()->extraVars('{ "key1": "value1" }');
      * ```
      *
      * @param string|array $extraVars

--- a/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
+++ b/Tests/Asm/Ansible/Command/AnsiblePlaybookTest.php
@@ -802,14 +802,21 @@ class AnsiblePlaybookTest extends AnsibleTestCase
         //$playbookFile = $this->getSamplesPathFor(AnsiblePlaybook::class) . '/playbook1.yml';
 
         $tests = [
+            // Test empty strings (with & without spaces).
             [
                 'input' => '',
                 'expect' => false,
             ],
             [
+                'input' => '   ',
+                'expect' => false,
+            ],
+            // Test empty array.
+            [
                 'input' => [],
                 'expect' => false,
             ],
+            // Test Arrays
             [
                 'input' => ['key' => 'value'],
                 'expect' => '--extra-vars=key=value',
@@ -818,6 +825,12 @@ class AnsiblePlaybookTest extends AnsibleTestCase
                 'input' => ['key1' => 'value1', 'key2' => 'value2'],
                 'expect' => '--extra-vars=key1=value1 key2=value2',
             ],
+            // Test valid JSON.
+            [
+                'input' => '{ "key1": "value1", "key2": "value2" }',
+                'expect' => '--extra-vars={ "key1": "value1", "key2": "value2" }',
+            ],
+            // Test key value string.
             [
                 'input' => 'key=value',
                 'expect' => '--extra-vars=key=value',


### PR DESCRIPTION
PR #87 has removed the tests that were introduced for the scenario where a JSON string is used for the `--extra-vars` parameter. This functionality was introduced via #86 