### PR TITLE
Adding support of symfony/process ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0.0|^8.1.0|^8.2.0",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/process": "^5.3|^6.0"
+        "symfony/process": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5|^10.0 ",


### PR DESCRIPTION
I want support for symfony/process ^7.0 to be able to use php-ansible on Symfony7.0.

I have tested with PHP8.1, 8.2, and 8.3:

1) with PHP8.1:
> composer update set symfony/process to v.6.4.7
> phpunit stay **OK** (73 tests, 140 assertions)

2) with PHP8.2:
> composer update set symfony/process to v.7.0.7
> phpunit stay **OK** (73 tests, 140 assertions)

3) with PHP8.3:
> composer update set symfony/process to v.7.0.7
> I get this error:
```
1) Asm\Ansible\Command\AnsibleGalaxyTest::testExecute
Symfony\Component\Process\Exception\RuntimeException: Unable to launch a new process.
```
But **i get the same error with current php-ansible version (how use symfony/process to v.6.4.7)**. So i think we can path through the php 8.3 compatibility for this merge request?

Not that i try to fix quickly the php8.3 issue but i didn't understood the problem. I wonder if i miss a php8.3-* package on my system... Is anybody can make the same test to check this possibility?
